### PR TITLE
fix(dep-graph): allow a mix of external and internal dependencies with the same name

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -276,16 +276,13 @@ func (c *Context) ResolveWorkspaceRootDeps(rootPackageJSON *fs.PackageJSON) erro
 	pkg := rootPackageJSON
 	depSet := mapset.NewSet()
 	pkg.UnresolvedExternalDeps = make(map[string]string)
-	for dep, version := range pkg.Dependencies {
-		pkg.UnresolvedExternalDeps[dep] = version
-	}
 	for dep, version := range pkg.DevDependencies {
 		pkg.UnresolvedExternalDeps[dep] = version
 	}
 	for dep, version := range pkg.OptionalDependencies {
 		pkg.UnresolvedExternalDeps[dep] = version
 	}
-	for dep, version := range pkg.PeerDependencies {
+	for dep, version := range pkg.Dependencies {
 		pkg.UnresolvedExternalDeps[dep] = version
 	}
 	if util.IsYarn(c.Backend.Name) {
@@ -345,10 +342,6 @@ func (c *Context) populateTopologicGraphForPackageJson(pkg *fs.PackageJSON) erro
 	externalDepSet := mapset.NewSet()
 	pkg.UnresolvedExternalDeps = make(map[string]string)
 
-	for dep, version := range pkg.Dependencies {
-		depMap[dep] = version
-	}
-
 	for dep, version := range pkg.DevDependencies {
 		depMap[dep] = version
 	}
@@ -357,7 +350,7 @@ func (c *Context) populateTopologicGraphForPackageJson(pkg *fs.PackageJSON) erro
 		depMap[dep] = version
 	}
 
-	for dep, version := range pkg.PeerDependencies {
+	for dep, version := range pkg.Dependencies {
 		depMap[dep] = version
 	}
 
@@ -368,7 +361,7 @@ func (c *Context) populateTopologicGraphForPackageJson(pkg *fs.PackageJSON) erro
 		if err != nil {
 			return err
 		}
-			
+
 		if isInternal {
 			internalDepsSet.Add(dependencyName)
 			c.TopologicalGraph.Connect(dag.BasicEdge(pkg.Name, dependencyName))
@@ -379,15 +372,15 @@ func (c *Context) populateTopologicGraphForPackageJson(pkg *fs.PackageJSON) erro
 
 	for _, name := range externalUnresolvedDepsSet.List() {
 		name := name.(string)
-		if item, ok := pkg.Dependencies[name]; ok {
-			pkg.UnresolvedExternalDeps[name] = item
-		}
-
 		if item, ok := pkg.DevDependencies[name]; ok {
 			pkg.UnresolvedExternalDeps[name] = item
 		}
 
 		if item, ok := pkg.OptionalDependencies[name]; ok {
+			pkg.UnresolvedExternalDeps[name] = item
+		}
+
+		if item, ok := pkg.Dependencies[name]; ok {
 			pkg.UnresolvedExternalDeps[name] = item
 		}
 	}


### PR DESCRIPTION
See individual commits:
### fix(dep-graph): allow mix of internal and external deps with same name
When turbo currently tries to build the dependency graph, it doesn't consider the specified
version/range of the dependency, it just assumes that if that package name exists in the
workspace it must be an internal dependency. Because of this the cycles are detected and
the process hangs.

This PR adds some additional logic to ensure that dependencies are only considered
internal if the local/workspace package's version matches the semver range specified for
the dependency.

### chore(peer-deps): don't consider peer deps when constructing graph
If a package has a peer dependency but there is no corresponding devDependency, then it
should be presumed that there are no build-time dependency on that package. For example,
if there was code that would be executed by one of the scripts that tried to import from the
peer package, this would generally speaking fail, but may be working by accident due to hoisting.

I have also changed the order in which dependencies, optionalDependencies, and devDependencies
are selected to match the order that lerna uses for cases where the package shows up in multiple
places.
See: https://github.com/lerna/lerna/blob/a47fc294393a3e9507a8207a5a2f07648a524722/core/package-graph/index.js#L53-L58